### PR TITLE
Store clicked time for clock actions and improve geolocation timeout

### DIFF
--- a/app/components/ClockInOut.tsx
+++ b/app/components/ClockInOut.tsx
@@ -133,8 +133,7 @@ const ClockInOut = () => {
 
   const handleButtonClick = async () => {
     if (!clickedTimeRef.current) {
-      const clickedTime = getTimeOnly();
-      console.log("time clicked", clickedTime);
+      const clickedTime = getTimeOnly();      
       clickedTimeRef.current = clickedTime;
     }
 
@@ -333,7 +332,7 @@ const ClockInOut = () => {
           },
           {
             enableHighAccuracy: true,
-            timeout: 5000,
+            timeout: 15000,
             maximumAge: 0,
           }
         );

--- a/app/components/ClockInOut.tsx
+++ b/app/components/ClockInOut.tsx
@@ -78,6 +78,7 @@ const ClockInOut = () => {
   const [time, setTime] = useState(0);
   const [capturedProof, setCapturedProof] = useState<File | null>(null);
   const [capturedProofUrl, setCapturedProofUrl] = useState<string | null>(null);
+  const clickedTimeRef = useRef<string | null>(null);
   const isWorkDay = useMemo(() => {
     const todayDay = new Date().getDay();
     return (
@@ -131,6 +132,14 @@ const ClockInOut = () => {
   }, [status.clockIn, isWorkDay]);
 
   const handleButtonClick = async () => {
+    if (!clickedTimeRef.current) {
+      const clickedTime = getTimeOnly();
+      console.log("time clicked", clickedTime);
+      clickedTimeRef.current = clickedTime;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
     try {
       setSending(true);
 
@@ -218,7 +227,7 @@ const ClockInOut = () => {
   }) => {
     const formData = new FormData();
     formData.append("type", type);
-    formData.append("clock_in_time", getTimeOnly());
+    formData.append("clock_in_time", clickedTimeRef.current!);
     formData.append("clock_in_latitude", latitude.toString());
     formData.append("clock_in_longitude", longitude.toString());
     if (capturedProof) {
@@ -261,11 +270,11 @@ const ClockInOut = () => {
       proof: capturedProof,
     };
     if (type === "clock-out") {
-      sendData["clock_out_time"] = getTimeOnly();
+      sendData["clock_out_time"] = clickedTimeRef.current!;
       sendData["clock_out_latitude"] = latitude;
       sendData["clock_out_longitude"] = longitude;
     } else {
-      sendData["clock_in_time"] = getTimeOnly();
+      sendData["clock_in_time"] = clickedTimeRef.current!;
       sendData["clock_in_latitude"] = latitude;
       sendData["clock_in_longitude"] = longitude;
     }
@@ -296,7 +305,7 @@ const ClockInOut = () => {
         } else {
           formData.append(key, value);
         }
-      });
+      });      
       const res = await fetch(`/api/user/attendance`, {
         method: "POST",
         body: formData,
@@ -400,7 +409,7 @@ const ClockInOut = () => {
       setTime(Date.now());
     }, 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, []);  
 
   const handleGeolocationError = useCallback(
     (error: PositionErrorCallback | any) => {

--- a/app/components/ClockInOut.tsx
+++ b/app/components/ClockInOut.tsx
@@ -332,7 +332,7 @@ const ClockInOut = () => {
           },
           {
             enableHighAccuracy: true,
-            timeout: 15000,
+            timeout: 300000,
             maximumAge: 0,
           }
         );


### PR DESCRIPTION
Store the time when the clock in/out button is clicked to ensure accurate timestamps. Increase geolocation timeout to enhance location accuracy and remove unnecessary console logs.