### PR TITLE
Fix migration naming convention and add manual clock-out endpoint for admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ Endpoint to send request when admin manually clockout an employee
 
 #### Required Field
 
-| Field | Type | Example |
-|-------|------|---------|
-| `clock_out_time` | `string` | `09:00:00`|
-| `clock_out_proof`|`File`| |
-| `work[]`|`string[]`|`["work", "work"]`|
+| Field | Type | Example | Detail |
+|-------|------|---------|--------|
+| `clock_out_time` | `string` | `09:00:00`| |
+| `clock_out_proof`|`File`| | |
+| `work`|`string`|`["work", "work"]`| A json that is stringify or encoded |
 
 #### Success Response
 
@@ -197,7 +197,7 @@ Endpoint to send request when admin manually clockout an employee
         "clock_out_latitude": null,
         "clock_out_longitude": null,
         "clock_out_picture": "/upload/log-proof/***",
-        "works": ["work", "work"]
+        "works": ["work", "work"],
     }
 
 ## Holidays Resource

--- a/app/api/attendances/manual-clock-out/route.ts
+++ b/app/api/attendances/manual-clock-out/route.ts
@@ -21,8 +21,15 @@ const POST = async (req: NextRequest) => {
     logId = Number(logId);
     if (isNaN(logId)) return NextResponse.json({error: "log_id bukan sebuah angka"}, {status: 422});
 
-    const works = formData.getAll("work[]") as string[] | null;
-    if (!works || works.length === 0) return NextResponse.json({error: "Pekerjaan dibutuhkan"}, {status: 422});
+    let works = formData.get("work") as string | null | string[];
+    if (!works) return NextResponse.json({error: "Pekerjaan dibutuhkan"}, {status: 422});
+    try {
+        works = JSON.parse(works as string) as string[];
+    } catch (error) {
+        console.error(error);
+        return NextResponse.json({error: "Pekerjaan harus json_encoded"})
+    }
+    if (works.length === 0) return NextResponse.json({error: "Pekerjaan tidak boleh kosong"}, {status: 422});
 
     const clockOutTime = formData.get("clock_out_time") as string | null;
     if (!clockOutTime) return NextResponse.json({error: "Jam pulang tidak ditemukan"}, {status: 422});


### PR DESCRIPTION
Address migration naming issues and introduce a new endpoint for admins to manually clock out employees, enhancing the clock-out response with additional fields and improved error handling.